### PR TITLE
Added a check to only manage keys of type string, and nil values are …

### DIFF
--- a/RedisCommon/redis.go
+++ b/RedisCommon/redis.go
@@ -417,8 +417,14 @@ type SearchResult struct {
 
 func ToMap(res []interface{}) map[string]string {
 	m := make(map[string]string, len(res)/2)
-	for i := 0; i < len(res); i += 2 {
-		m[res[i].(string)] = res[i+1].(string)
+	for i := 0; i < len(res)-1; i += 2 {
+		key, ok := res[i].(string)
+		if !ok {
+			continue // skip if the key is not a string
+		}
+
+		val, _ := res[i+1].(string) // default ""
+		m[key] = val
 	}
 	return m
 }


### PR DESCRIPTION
When opening the "List tables" without any query running, the cli crashes.

```
Connected to Redis at 'localhost:6379' for application keyspace 'SmartCacheForMySQL'.

    == Main menu ==

    List application queries
  > List tables
    List query caching rules
    Create query caching rule






    ↑/k up • ↓/j down • q quit • ? more

Caught panic:

interface conversion: interface {} is nil, not string

Restoring terminal...

goroutine 1 [running]:
runtime/debug.Stack()
	/Users/steve.lorello/.go/src/runtime/debug/stack.go:24 +0x65
runtime/debug.PrintStack()
	/Users/steve.lorello/.go/src/runtime/debug/stack.go:16 +0x19
github.com/charmbracelet/bubbletea.(*Program).Run.func1()
	/Users/steve.lorello/go/pkg/mod/github.com/charmbracelet/bubbletea@v0.23.2/tea.go:402 +0x95
panic({0x8f3580, 0xc000426210})
	/Users/steve.lorello/.go/src/runtime/panic.go:890 +0x263
smart-cache-cli/RedisCommon.ToMap(...)
	/Users/steve.lorello/projects/redis/redis-smart-cache-cli/RedisCommon/redis.go:421
smart-cache-cli/RedisCommon.GetTables(0x0?, {0x7ffffffffefb, 0x12})
	/Users/steve.lorello/projects/redis/redis-smart-cache-cli/RedisCommon/redis.go:119 +0xb3e
smart-cache-cli/TableList.New({_, _}, _, {_, _})
	/Users/steve.lorello/projects/redis/redis-smart-cache-cli/TableList/TableList.go:114 +0x88
smart-cache-cli/mainMenu.Model.Update({{0x1, 0x1, 0x0, 0x1, 0x1, 0x0, {0x962734, 0x4}, {0x962c1e, 0x5}, ...}, ...}, ...)

...
```

By adding a check if the key is of type string and by converting nil values to empty string, it will fix the issues.